### PR TITLE
chore: remove Mockito from dev dependencies as it wasn't being used

### DIFF
--- a/custom_slide_context_tile/pubspec.yaml
+++ b/custom_slide_context_tile/pubspec.yaml
@@ -16,6 +16,5 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^4.0.0
   dart_code_metrics:
-  mockito: ^5.4.4
 
 flutter:


### PR DESCRIPTION
This PR removes **Mockito** from dev dependencies.