### PR TITLE
chore: rename CI job

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 jobs:
   test:
+    name: "Code Quality and Testing"
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
## What

Added a descriptive name to the `test` job in the CI configuration.

## Why

To improve clarity and understanding of the job’s purpose within the CI pipeline.