### PR TITLE
fix: dismiss open popups on window resize to prevent position errors

### DIFF
--- a/custom_popup/lib/src/popup/custom_popup_route.dart
+++ b/custom_popup/lib/src/popup/custom_popup_route.dart
@@ -255,10 +255,10 @@ class CustomPopupRoute extends PopupRoute<VoidCallback?> {
       calculatePopupPosition();
     });
 
-    // if (context.mounted) {
-    //   // Use the Navigator to pop the top route if it's a PopupRoute
-    //   Navigator.of(context).popUntil((route) => route is! PopupRoute);
-    // }
+    if (context.mounted) {
+      // Use the Navigator to pop the top route if it's a PopupRoute
+      Navigator.of(context).popUntil((route) => route is! PopupRoute);
+    }
   }
 
   @override


### PR DESCRIPTION
### What
This PR addresses an issue that occurs when a window is resized while an open popup is active. The changes include:

- **Fixed Route Popping Behavior**: Implemented a check to determine if the current route is a `PopupRoute` before allowing it to be popped. This prevents unintended route popping when resizing a window with an open popup.

### Why
The previous implementation led to unexpected behavior where resizing the window caused the application to pop the active route, even if it was not a `PopupRoute`. This could disrupt user interactions and lead to a confusing experience. By adding a check for `PopupRoute`, we ensure that only appropriate routes are affected by window resizing, thus improving stability and user experience.