### PR TITLE
feat: add labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,11 +1,17 @@
-name: "Automated PR Classification"
+name: "PR Classification"
+
+# This workflow automatically classifies pull requests by applying labels based on:
+# 1. The type of change (feature, bug fix, chore, etc.) derived from commit messages.
+# 2. The specific package being modified (custom_popup, custom_slide_context_tile, or general).
+#
+# It runs on pull request events (opened, synchronize, reopened) to ensure labels are up-to-date.
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
 
 jobs:
-  label:
+  classify:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -14,7 +20,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Analyze commits and apply labels
+      - name: Classify PR and apply labels
         uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -22,13 +28,21 @@ jobs:
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;
             
+            // Get the list of changed files
+            const { data: changedFiles } = await github.rest.pulls.listFiles({
+              owner,
+              repo,
+              pull_number: pr.number,
+            });
+            
+            const labels = new Set();
+            
+            // Check commit messages for conventional commit types
             const commits = await github.rest.pulls.listCommits({
               owner,
               repo,
               pull_number: pr.number,
             });
-
-            const labels = new Set();
 
             commits.data.forEach(commit => {
               const message = commit.commit.message.toLowerCase();
@@ -44,6 +58,17 @@ jobs:
                 labels.add('refactor');
               } else if (message.startsWith('test')) {
                 labels.add('test');
+              }
+            });
+            
+            // Check changed files for package-specific changes
+            changedFiles.forEach(file => {
+              if (file.filename.startsWith('custom_popup/')) {
+                labels.add('package: custom_popup');
+              } else if (file.filename.startsWith('custom_slide_context_tile/')) {
+                labels.add('package: custom_slide_context_tile');
+              } else {
+                labels.add('general');
               }
             });
 


### PR DESCRIPTION
### What

This PR introduces a GitHub Actions workflow that automatically labels pull requests based on commit message prefixes (e.g., `chore`, `test`, `feat`, `refactor`, `docs`).

### Why

Automating the labeling process ensures consistency and saves time, making it easier to manage and review pull requests.