### PR TITLE
Feature/add foreground color menu action

### DIFF
--- a/custom_slide_context_tile/example/lib/main.dart
+++ b/custom_slide_context_tile/example/lib/main.dart
@@ -69,7 +69,8 @@ class _MyHomePageState extends State<MyHomePage> {
           // Action when button is pressed
           onPressed: () => log('Leading action executed'),
           label: 'Delete',
-          backgroundColor: Colors.red,
+          foregroundColor: Colors.red,
+          backgroundColor: Colors.white,
         ),
       ];
 

--- a/custom_slide_context_tile/lib/src/widgets/menu_action.dart
+++ b/custom_slide_context_tile/lib/src/widgets/menu_action.dart
@@ -12,12 +12,14 @@ class MenuAction extends StatefulWidget {
   /// [onPressed] is the callback function to be executed when the action is tapped.
   /// [icon] is the IconData to be displayed for this action.
   /// [label] is an optional text label for the action.
+  /// [foregroundColor] is an optional custom foreground color for the label and icon.
   /// [backgroundColor] is an optional custom background color for the action item.
   /// [isDestructive] indicates whether this action should be styled as destructive.
   const MenuAction({
     required this.onPressed,
     required this.icon,
     this.label,
+    this.foregroundColor,
     this.backgroundColor,
     this.isDestructive = false,
     super.key,
@@ -28,6 +30,11 @@ class MenuAction extends StatefulWidget {
 
   /// The icon to be displayed for this action.
   final IconData icon;
+
+  /// The foreground color of the action item. This color is used to style the
+  /// text label and icon. If null, it defaults to the theme's text color for the
+  /// label and the theme's icon color for the icon.
+  final Color? foregroundColor;
 
   /// The background color of the action item. If null, defaults to the scaffold background color.
   final Color? backgroundColor;
@@ -45,7 +52,9 @@ class MenuAction extends StatefulWidget {
 class _MenuActionState extends State<MenuAction> {
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final scope = MenuActionScope.of(context);
+
     // Determine whether to show the label based on the MenuActionScope and if a label is provided
     final showLabel = (widget.label != null && scope.showLabels);
 
@@ -58,7 +67,7 @@ class _MenuActionState extends State<MenuAction> {
 
     // Use the provided background color or default to the scaffold background color
     final backgroundColor =
-        widget.backgroundColor ?? Theme.of(context).scaffoldBackgroundColor;
+        widget.backgroundColor ?? theme.scaffoldBackgroundColor;
 
     final alignment = shouldExpandDefaultAction
         ? isLeading
@@ -88,12 +97,19 @@ class _MenuActionState extends State<MenuAction> {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(widget.icon),
+                  Icon(
+                    widget.icon,
+                    color: widget.foregroundColor ?? theme.iconTheme.color,
+                  ),
                   if (showLabel)
                     Text(
                       widget.label!,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: widget.foregroundColor ??
+                            theme.textTheme.bodyMedium!.color,
+                      ),
                     ),
                 ],
               ),


### PR DESCRIPTION
### What

This PR introduces a new `foregroundColor` property to the `MenuAction` widget and updates related components:

1. Added `foregroundColor` property to `MenuAction`:
   - This property allows customization of the color for both the icon and label within the `MenuAction`.

2. Updated `MenuAction` tests:
   - Added new test cases to verify the `foregroundColor` is correctly applied to both the icon and label.

3. Updated the example:
   - Modified the example to demonstrate the usage of the new `foregroundColor` property.

### Why

These changes aim to:

1. Enhance the customization options for `MenuAction` widgets.
2. Provide developers with more control over the visual appearance of menu actions.
3. Ensure consistency in color application across both icon and label elements.