### PR TITLE
Feature/custom slide context tile padding

### DIFF
--- a/custom_slide_context_tile/example/lib/main.dart
+++ b/custom_slide_context_tile/example/lib/main.dart
@@ -158,7 +158,8 @@ class _MyHomePageState extends State<MyHomePage> {
               trailingActions: trailingActions,
               revealAnimationType: RevealAnimationType.pull,
               title: const Text('Swipe me'),
-              subtitle: const Text('Subtitle'),
+              subtitle: const Text('Custom Padding'),
+              padding: EdgeInsets.zero,
             ),
             const SizedBox(height: 8.0),
             CustomSlideContextTile(

--- a/custom_slide_context_tile/lib/src/custom_slide_context_tile.dart
+++ b/custom_slide_context_tile/lib/src/custom_slide_context_tile.dart
@@ -61,6 +61,7 @@ class CustomSlideContextTile extends StatefulWidget {
     this.subtitle,
     this.leading,
     this.trailing,
+    this.padding,
     this.leadingActions = const [],
     this.trailingActions = const [],
     this.actionExecutionThreshold = 100.0,
@@ -111,6 +112,7 @@ class CustomSlideContextTile extends StatefulWidget {
     this.subtitle,
     this.leading,
     this.trailing,
+    this.padding,
     this.leadingActions = const [],
     this.trailingActions = const [],
     this.actionExecutionThreshold = 100.0,
@@ -160,6 +162,7 @@ class CustomSlideContextTile extends StatefulWidget {
     this.subtitle,
     this.leading,
     this.trailing,
+    this.padding,
     this.leadingActions = const [],
     this.trailingActions = const [],
     this.actionExecutionThreshold = 100.0,
@@ -190,6 +193,12 @@ class CustomSlideContextTile extends StatefulWidget {
   /// An optional trailing widget displayed on the right side of the tile. This is
   /// usually a right chevron icon (e.g. CupertinoListTileChevron), or an Icon.
   final Widget? trailing;
+
+  /// Custom padding for the list tile.
+  ///
+  /// If null, the default padding of the list tile will be used.
+  /// This allows for customization of the space around the tile's content.
+  final EdgeInsets? padding;
 
   /// Actions to be displayed on the leading (left) side when sliding.
   /// These actions are revealed when the user slides the tile to the right.
@@ -345,6 +354,7 @@ class _CustomSlideContextTileState extends State<CustomSlideContextTile>
         subtitle: widget.subtitle,
         leading: widget.leading,
         trailing: widget.trailing,
+        padding: widget.padding,
         onTap: _internalController.isOpen ? null : widget.onTap,
         useAdaptiveListTile: widget.useAdaptiveListTile,
       );

--- a/custom_slide_context_tile/lib/src/widgets/adaptive_list_tile.dart
+++ b/custom_slide_context_tile/lib/src/widgets/adaptive_list_tile.dart
@@ -22,6 +22,7 @@ class AdaptiveListTile extends StatelessWidget {
     this.subtitle,
     this.leading,
     this.trailing,
+    this.padding,
     this.onTap,
     this.useAdaptiveListTile = false,
   });
@@ -52,6 +53,12 @@ class AdaptiveListTile extends StatelessWidget {
   /// To show right-aligned metadata instead of a trailing icon (e.g., the time of a message),
   /// consider using [ListTile.isThreeLine] and [ListTile.subtitle].
   final Widget? trailing;
+
+  /// Custom padding for the list tile.
+  ///
+  /// If null, the default padding of the list tile will be used.
+  /// This allows for customization of the space around the tile's content.
+  final EdgeInsets? padding;
 
   /// Called when the user taps this list tile.
   ///
@@ -86,6 +93,7 @@ class AdaptiveListTile extends StatelessWidget {
             subtitle: subtitle,
             leading: leading,
             trailing: trailing,
+            contentPadding: padding,
             onTap: onTap,
           ),
         ),
@@ -97,6 +105,7 @@ class AdaptiveListTile extends StatelessWidget {
         subtitle: subtitle,
         leading: leading,
         trailing: trailing,
+        padding: padding,
         onTap: onTap,
         backgroundColor: CupertinoColors.systemBackground,
       );

--- a/custom_slide_context_tile/test/widgets/adaptive_list_tile_test.dart
+++ b/custom_slide_context_tile/test/widgets/adaptive_list_tile_test.dart
@@ -5,10 +5,83 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('AdaptiveListTile Tests', () {
-    for (final platform in TargetPlatform.values) {
-      testWidgets(
-        'uses CupertinoListTile when not adaptive on $platform',
-        (WidgetTester tester) async {
+    group('Platform-soecific rendering', () {
+      for (final platform in TargetPlatform.values) {
+        testWidgets(
+          'uses CupertinoListTile when not adaptive on $platform',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(
+              MaterialApp(
+                theme: ThemeData(platform: platform),
+                home: const AdaptiveListTile(
+                  title: Text('Test'),
+                  useAdaptiveListTile: false,
+                ),
+              ),
+            );
+            expect(find.byType(CupertinoListTile), findsOneWidget);
+            expect(find.byType(ListTile), findsNothing);
+          },
+        );
+      }
+
+      for (final platform in TargetPlatform.values) {
+        testWidgets(
+            'uses the proper list tile widget when useAdaptiveListTile is true on $platform',
+            (WidgetTester tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              theme: ThemeData(platform: platform),
+              home: const AdaptiveListTile(
+                title: Text('Test'),
+                useAdaptiveListTile: true,
+              ),
+            ),
+          );
+          if (platform == TargetPlatform.iOS ||
+              platform == TargetPlatform.macOS) {
+            expect(find.byType(CupertinoListTile), findsOneWidget);
+            expect(find.byType(ListTile), findsNothing);
+          } else {
+            expect(find.byType(ListTile), findsOneWidget);
+            expect(find.byType(CupertinoListTile), findsNothing);
+          }
+        });
+      }
+
+      for (final platform in TargetPlatform.values) {
+        testWidgets('uses correct background color on $platform',
+            (WidgetTester tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              theme: ThemeData(
+                platform: platform,
+                scaffoldBackgroundColor: Colors.grey[200],
+              ),
+              home: const AdaptiveListTile(
+                title: Text('Test'),
+                useAdaptiveListTile: true,
+              ),
+            ),
+          );
+
+          if (platform == TargetPlatform.iOS ||
+              platform == TargetPlatform.macOS) {
+            final CupertinoListTile listTile =
+                tester.widget(find.byType(CupertinoListTile));
+            expect(listTile.backgroundColor, CupertinoColors.systemBackground);
+          } else {
+            final ColoredBox coloredBox =
+                tester.widget(find.byType(ColoredBox));
+            expect(coloredBox.color, Colors.grey[200]);
+          }
+        });
+      }
+
+      for (final platform in TargetPlatform.values
+          .where((p) => p != TargetPlatform.iOS && p != TargetPlatform.macOS)) {
+        testWidgets('uses CupertinoListTile when not adaptive on $platform',
+            (WidgetTester tester) async {
           await tester.pumpWidget(
             MaterialApp(
               theme: ThemeData(platform: platform),
@@ -20,142 +93,159 @@ void main() {
           );
           expect(find.byType(CupertinoListTile), findsOneWidget);
           expect(find.byType(ListTile), findsNothing);
-        },
-      );
-    }
+        });
+      }
+    });
 
-    for (final platform in TargetPlatform.values) {
-      testWidgets(
-          'uses the proper list tile widget when useAdaptiveListTile is true on $platform',
+    group('Content rendering', () {
+      testWidgets('renders title and subtitle correctly',
           (WidgetTester tester) async {
+        const titleText = 'Test Title';
+        const subtitleText = 'Test Subtitle';
         await tester.pumpWidget(
-          MaterialApp(
-            theme: ThemeData(platform: platform),
-            home: const AdaptiveListTile(
-              title: Text('Test'),
-              useAdaptiveListTile: true,
+          const MaterialApp(
+            home: AdaptiveListTile(
+              title: Text(titleText),
+              subtitle: Text(subtitleText),
             ),
           ),
         );
-        if (platform == TargetPlatform.iOS ||
-            platform == TargetPlatform.macOS) {
-          expect(find.byType(CupertinoListTile), findsOneWidget);
-          expect(find.byType(ListTile), findsNothing);
-        } else {
-          expect(find.byType(ListTile), findsOneWidget);
-          expect(find.byType(CupertinoListTile), findsNothing);
-        }
+        expect(find.text(titleText), findsOneWidget);
+        expect(find.text(subtitleText), findsOneWidget);
       });
-    }
 
-    testWidgets('renders title and subtitle correctly',
-        (WidgetTester tester) async {
-      const titleText = 'Test Title';
-      const subtitleText = 'Test Subtitle';
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: AdaptiveListTile(
-            title: Text(titleText),
-            subtitle: Text(subtitleText),
-          ),
-        ),
-      );
-      expect(find.text(titleText), findsOneWidget);
-      expect(find.text(subtitleText), findsOneWidget);
-    });
-
-    testWidgets('does not render subtitle when not provided',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: AdaptiveListTile(
-            title: Text('Test Title'),
-          ),
-        ),
-      );
-      expect(find.text('Test Title'), findsOneWidget);
-      // Only title should be present
-      expect(find.byType(Text), findsOneWidget);
-    });
-
-    testWidgets('renders leading and trailing widgets',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: AdaptiveListTile(
-            title: Text('Test'),
-            leading: Icon(Icons.star),
-            trailing: Icon(Icons.arrow_forward),
-          ),
-        ),
-      );
-      expect(find.byIcon(Icons.star), findsOneWidget);
-      expect(find.byIcon(Icons.arrow_forward), findsOneWidget);
-    });
-
-    testWidgets('calls onTap when tapped', (WidgetTester tester) async {
-      bool wasTapped = false;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: AdaptiveListTile(
-            title: const Text('Test'),
-            onTap: () => wasTapped = true,
-          ),
-        ),
-      );
-      await tester.tap(find.byType(AdaptiveListTile));
-      expect(wasTapped, isTrue);
-    });
-
-    testWidgets('does not call onTap when not provided',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: AdaptiveListTile(
-            title: Text('Test'),
-          ),
-        ),
-      );
-      await tester.tap(find.byType(AdaptiveListTile));
-      // If no exception is thrown, the test passes
-    });
-
-    testWidgets('has minimum height constraint', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: AdaptiveListTile(title: Text('Test')),
-        ),
-      );
-      final RenderBox box = tester.renderObject(find.byType(AdaptiveListTile));
-      expect(box.size.height, greaterThanOrEqualTo(48));
-    });
-
-    for (final platform in TargetPlatform.values) {
-      testWidgets('uses correct background color on $platform',
+      testWidgets('does not render subtitle when not provided',
           (WidgetTester tester) async {
         await tester.pumpWidget(
-          MaterialApp(
-            theme: ThemeData(
-              platform: platform,
-              scaffoldBackgroundColor: Colors.grey[200],
+          const MaterialApp(
+            home: AdaptiveListTile(
+              title: Text('Test Title'),
             ),
-            home: const AdaptiveListTile(
+          ),
+        );
+        expect(find.text('Test Title'), findsOneWidget);
+        // Only title should be present
+        expect(find.byType(Text), findsOneWidget);
+      });
+
+      testWidgets('renders leading and trailing widgets',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: AdaptiveListTile(
               title: Text('Test'),
-              useAdaptiveListTile: true,
+              leading: Icon(Icons.star),
+              trailing: Icon(Icons.arrow_forward),
+            ),
+          ),
+        );
+        expect(find.byIcon(Icons.star), findsOneWidget);
+        expect(find.byIcon(Icons.arrow_forward), findsOneWidget);
+      });
+
+      testWidgets('wraps to multiple lines for long text',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: SizedBox(
+              width: 200,
+              child: AdaptiveListTile(
+                title: Text(
+                    'This is a very long title that should wrap to multiple lines',
+                    maxLines: 2),
+              ),
             ),
           ),
         );
 
-        if (platform == TargetPlatform.iOS ||
-            platform == TargetPlatform.macOS) {
-          final CupertinoListTile listTile =
-              tester.widget(find.byType(CupertinoListTile));
-          expect(listTile.backgroundColor, CupertinoColors.systemBackground);
-        } else {
-          final ColoredBox coloredBox = tester.widget(find.byType(ColoredBox));
-          expect(coloredBox.color, Colors.grey[200]);
-        }
+        final RenderBox box = tester.renderObject(find.byType(Text));
+        expect(box.size.height, greaterThan(24));
       });
-    }
+    });
+
+    group('Interaction', () {
+      testWidgets('calls onTap when tapped', (WidgetTester tester) async {
+        bool wasTapped = false;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: AdaptiveListTile(
+              title: const Text('Test'),
+              onTap: () => wasTapped = true,
+            ),
+          ),
+        );
+        await tester.tap(find.byType(AdaptiveListTile));
+        expect(wasTapped, isTrue);
+      });
+
+      testWidgets('does not call onTap when not provided',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: AdaptiveListTile(
+              title: Text('Test'),
+            ),
+          ),
+        );
+        await tester.tap(find.byType(AdaptiveListTile));
+        // If no exception is thrown, the test passes
+      });
+    });
+
+    group('Layout and Styling', () {
+      testWidgets('has minimum height constraint', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: AdaptiveListTile(title: Text('Test')),
+          ),
+        );
+        final RenderBox box =
+            tester.renderObject(find.byType(AdaptiveListTile));
+        expect(box.size.height, greaterThanOrEqualTo(48));
+      });
+
+      testWidgets('uses default padding when not specified',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: AdaptiveListTile(
+              title: Text('Test'),
+            ),
+          ),
+        );
+
+        final listTile =
+            tester.widget<CupertinoListTile>(find.byType(CupertinoListTile));
+        expect(listTile.padding, null);
+      });
+
+      for (final platform in TargetPlatform.values) {
+        testWidgets('respects custom padding in $platform',
+            (WidgetTester tester) async {
+          final isApplePlatform = platform == TargetPlatform.iOS ||
+              platform == TargetPlatform.macOS;
+
+          await tester.pumpWidget(
+            MaterialApp(
+              theme: ThemeData(platform: platform),
+              home: const AdaptiveListTile(
+                title: Text('Test'),
+                padding: EdgeInsets.all(10),
+                useAdaptiveListTile: true,
+              ),
+            ),
+          );
+
+          if (isApplePlatform) {
+            final CupertinoListTile listTile =
+                tester.widget(find.byType(CupertinoListTile));
+            expect(listTile.padding, const EdgeInsets.all(10));
+          } else {
+            final ListTile listTile = tester.widget(find.byType(ListTile));
+            expect(listTile.contentPadding, const EdgeInsets.all(10));
+          }
+        });
+      }
+    });
   });
 }


### PR DESCRIPTION
### What

This PR introduces a new `padding` property to `CustomSlideContextTile`:

1. Added a `padding` property to `CustomSlideContextTile`.
2. Updated internal implementations to support the new `padding` property.
3. Enhanced tests to cover the new `padding` functionality.
4. Updated the example app to demonstrate the usage of the new `padding` property.

### Why

These changes aim to:

1. Provide more flexibility in customizing the appearance of `CustomSlideContextTile`.
2. Allow users to adjust the internal `padding` of the widget to fit various design requirements.
3. Maintain consistency across different platforms (iOS and Android) when applying padding.
4. Improve the overall usability of the `custom_slide_context_tile` package.